### PR TITLE
add getBearerToken to exported functions

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,4 +2,4 @@ export {default as AuthRoutes} from './routing/AuthRoutes';
 export {default as PrivateRoute} from './routing/PrivateRoute';
 export {default as withAuth} from './withAuth';
 export {initReactDevise} from './config/index';
-export {addAuthorizationHeaderToRequest} from './actions/authTokenStore';
+export {addAuthorizationHeaderToRequest, getBearerToken} from './actions/authTokenStore';


### PR DESCRIPTION
Add _**getBearerToken**_ to the package exported functions.
Makes it easier for non apollo apps to add the token to requests without using a client.