### PR TITLE
Initialize `currentUser` state in redux store when necessary

### DIFF
--- a/src/reducers/currentUser.js
+++ b/src/reducers/currentUser.js
@@ -1,5 +1,5 @@
 import jwtDecode from 'jwt-decode';
-import { hasAuthToken, getAuthToken } from '..//actions/authTokenStore';
+import { hasAuthToken, getAuthToken } from '../actions/authTokenStore';
 
 const initialState = {};
 
@@ -18,7 +18,7 @@ const currentUser = (state = initialState, action) => {
     case 'LOGIN_FAILED':
       return initialState;
     default:
-      if (_.isEmpty(state) && hasAuthToken()) {
+      if (Object.keys(state).length === 0 && hasAuthToken()) { // Try to establish init state when it is empty
         return {
             isLoggedIn: true,
             ...jwtDecode(getAuthToken())

--- a/src/reducers/currentUser.js
+++ b/src/reducers/currentUser.js
@@ -1,4 +1,5 @@
 import jwtDecode from 'jwt-decode';
+import { hasAuthToken, getAuthToken } from '..//actions/authTokenStore';
 
 const initialState = {};
 
@@ -17,6 +18,12 @@ const currentUser = (state = initialState, action) => {
     case 'LOGIN_FAILED':
       return initialState;
     default:
+      if (_.isEmpty(state) && hasAuthToken()) {
+        return {
+            isLoggedIn: true,
+            ...jwtDecode(getAuthToken())
+          };
+      }
       return state;
   }
 };


### PR DESCRIPTION
There is a problem in current behavior:
* at the moment of user logging in, `currentUser` state is established in redux store. Authtoken is saved to local storage. Then it is load the component protected by `<PrivateRoute>`. `<PrivateRoute>` checks that `currentUser` is present in state and has `isLoggedIn`. So everything works.
* However, when the page is refreshed, there is no code to re-establish `currentUser` state  in redux store (unless `redux-persist` is used), even though the token is still in local storage. When  `<PrivateRoute>` tries to check `currentUser`, it can't find it. So it rejects the route.

This PR is to initialize `currentUser` state in redux store from local storage  upon page reload.

This PR is to address #16 